### PR TITLE
Add Logging tab for real-time service diagnostics

### DIFF
--- a/common/include/dirsize/db.h
+++ b/common/include/dirsize/db.h
@@ -48,6 +48,9 @@ public:
 
     // --- Size queries (used by shell extension) ---
 
+    // Get total number of entries in the database.
+    uint64_t GetEntryCount();
+
     // Look up the cached total size for a directory path.
     // Returns nullopt if not found.
     std::optional<uint64_t> GetSize(const std::wstring& path);

--- a/common/include/dirsize/ipc.h
+++ b/common/include/dirsize/ipc.h
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <string>
+#include <vector>
 
 namespace dirsize {
 
@@ -13,6 +14,7 @@ enum class IpcCommand : uint32_t {
     Recalculate = 1,    // Request rescan of a specific path
     GetStatus = 2,      // Query service/scanner status
     ReloadConfig = 3,   // Tell service to re-read config from registry
+    GetLog = 4,         // Retrieve recent log entries + service status
 };
 
 // Status codes returned by the service
@@ -21,6 +23,13 @@ enum class IpcStatus : uint32_t {
     Error = 1,
     Busy = 2,           // Scanner is currently running
     NotFound = 3,       // Path not in watched directories
+};
+
+// Log severity levels (shared between service and tray app)
+enum class LogSeverity : uint8_t {
+    Error = 0,
+    Info = 1,
+    Verbose = 2,
 };
 
 // Wire format for requests (followed by path data if applicable)
@@ -34,6 +43,24 @@ struct IpcResponseHeader {
     IpcStatus status;
     uint32_t dataLengthBytes;   // Length of additional data in bytes, 0 if none
 };
+
+// Wire format for a single log entry in GetLog response
+struct LogEntryWire {
+    int64_t timestampMs;        // Unix epoch milliseconds
+    LogSeverity severity;       // Error / Info / Verbose
+    uint16_t messageLength;     // Length in bytes of UTF-8 message text
+    // Followed by messageLength bytes of UTF-8 text
+};
+
+// Service status summary in GetLog response
+struct ServiceStatusWire {
+    uint8_t isScanning;         // 1 = scanning, 0 = idle
+    int64_t lastScanTimestamp;  // Unix epoch ms of last completed full scan
+    uint64_t dbEntryCount;      // Number of rows in dir_sizes table
+    uint64_t dbSizeBytes;       // Size of dirsize.db file on disk
+    uint16_t currentPathLength; // UTF-8 bytes for current scan path (0 if idle)
+    // Followed by currentPathLength bytes of UTF-8 path
+};
 #pragma pack(pop)
 
 // Client-side helper: send a command to the service and receive a response.
@@ -43,5 +70,13 @@ bool SendCommand(IpcCommand command, const std::wstring& path,
 
 // Convenience overload for commands without a path argument.
 bool SendCommand(IpcCommand command, IpcStatus& outStatus, uint32_t timeoutMs = 5000);
+
+// Client-side helper: retrieve log entries from the service.
+// sinceSeqNum: sequence number of last received entry (0 for first request).
+// outLatestSeqNum: updated to the latest sequence number (bit 31 set if truncated).
+// outData: raw payload containing ServiceStatusWire + LogEntryWire entries.
+bool SendGetLog(uint32_t sinceSeqNum, IpcStatus& outStatus,
+                uint32_t& outLatestSeqNum, std::vector<uint8_t>& outData,
+                uint32_t timeoutMs = 5000);
 
 } // namespace dirsize

--- a/common/src/db.cpp
+++ b/common/src/db.cpp
@@ -215,6 +215,21 @@ std::wstring Database::NormalizePath(const std::wstring& path) {
     return normalized;
 }
 
+uint64_t Database::GetEntryCount() {
+    std::lock_guard lock(m_mutex);
+    if (!m_db) return 0;
+
+    uint64_t count = 0;
+    sqlite3_stmt* stmt = nullptr;
+    if (sqlite3_prepare_v2(m_db, "SELECT COUNT(*) FROM dir_sizes", -1, &stmt, nullptr) == SQLITE_OK) {
+        if (sqlite3_step(stmt) == SQLITE_ROW) {
+            count = static_cast<uint64_t>(sqlite3_column_int64(stmt, 0));
+        }
+        sqlite3_finalize(stmt);
+    }
+    return count;
+}
+
 std::optional<uint64_t> Database::GetSize(const std::wstring& path) {
     std::lock_guard lock(m_mutex);
     if (!m_stmtGetSize) return std::nullopt;

--- a/common/src/ipc.cpp
+++ b/common/src/ipc.cpp
@@ -66,4 +66,74 @@ bool SendCommand(IpcCommand command, IpcStatus& outStatus, uint32_t timeoutMs) {
     return SendCommand(command, L"", outStatus, timeoutMs);
 }
 
+bool SendGetLog(uint32_t sinceSeqNum, IpcStatus& outStatus,
+                uint32_t& outLatestSeqNum, std::vector<uint8_t>& outData,
+                uint32_t timeoutMs) {
+    outData.clear();
+    outLatestSeqNum = 0;
+
+    if (!WaitNamedPipeW(kPipeName, timeoutMs)) {
+        return false;
+    }
+
+    HANDLE hPipe = CreateFileW(
+        kPipeName,
+        GENERIC_READ | GENERIC_WRITE,
+        0, nullptr, OPEN_EXISTING, 0, nullptr);
+
+    if (hPipe == INVALID_HANDLE_VALUE) {
+        return false;
+    }
+
+    DWORD mode = PIPE_READMODE_BYTE;
+    SetNamedPipeHandleState(hPipe, &mode, nullptr, nullptr);
+
+    // Send request: header + sinceSeqNum as raw bytes
+    IpcRequestHeader header;
+    header.command = IpcCommand::GetLog;
+    header.pathLengthBytes = sizeof(uint32_t);
+
+    DWORD written = 0;
+    bool ok = WriteFile(hPipe, &header, sizeof(header), &written, nullptr) &&
+              written == sizeof(header);
+
+    if (ok) {
+        ok = WriteFile(hPipe, &sinceSeqNum, sizeof(uint32_t), &written, nullptr) &&
+             written == sizeof(uint32_t);
+    }
+
+    // Read response header
+    if (ok) {
+        IpcResponseHeader response;
+        DWORD bytesRead = 0;
+        ok = ReadFile(hPipe, &response, sizeof(response), &bytesRead, nullptr) &&
+             bytesRead == sizeof(response);
+        if (ok) {
+            outStatus = response.status;
+            // Read the data payload
+            if (response.dataLengthBytes > 0) {
+                std::vector<uint8_t> payload(response.dataLengthBytes);
+                DWORD totalRead = 0;
+                while (totalRead < response.dataLengthBytes) {
+                    DWORD chunkRead = 0;
+                    if (!ReadFile(hPipe, payload.data() + totalRead,
+                                  response.dataLengthBytes - totalRead,
+                                  &chunkRead, nullptr) || chunkRead == 0) {
+                        ok = false;
+                        break;
+                    }
+                    totalRead += chunkRead;
+                }
+                if (ok && totalRead >= sizeof(uint32_t)) {
+                    std::memcpy(&outLatestSeqNum, payload.data(), sizeof(uint32_t));
+                    outData.assign(payload.begin() + sizeof(uint32_t), payload.end());
+                }
+            }
+        }
+    }
+
+    CloseHandle(hPipe);
+    return ok;
+}
+
 } // namespace dirsize

--- a/service/CMakeLists.txt
+++ b/service/CMakeLists.txt
@@ -5,6 +5,7 @@ add_executable(DirSizeSvc
     throttle.cpp
     ipc_server.cpp
     change_journal.cpp
+    log_buffer.cpp
 )
 
 target_link_libraries(DirSizeSvc PRIVATE

--- a/service/change_journal.cpp
+++ b/service/change_journal.cpp
@@ -1,5 +1,6 @@
 #include "change_journal.h"
 #include "scanner.h"
+#include "log_buffer.h"
 
 #include <set>
 #include <string>
@@ -35,6 +36,7 @@ bool ChangeJournalMonitor::Start(wchar_t driveLetter, HANDLE stopEvent) {
         nullptr);
 
     if (m_volumeHandle == INVALID_HANDLE_VALUE) {
+        Log(LogSeverity::Error, "Failed to open volume %c:", driveLetter);
         return false;
     }
 
@@ -47,6 +49,7 @@ bool ChangeJournalMonitor::Start(wchar_t driveLetter, HANDLE stopEvent) {
             nullptr, 0,
             &journalData, sizeof(journalData),
             &bytesReturned, nullptr)) {
+        Log(LogSeverity::Error, "Failed to query change journal for %c:", driveLetter);
         CloseHandle(m_volumeHandle);
         m_volumeHandle = INVALID_HANDLE_VALUE;
         return false;
@@ -65,6 +68,7 @@ bool ChangeJournalMonitor::Start(wchar_t driveLetter, HANDLE stopEvent) {
         m_lastUsn = journalData.NextUsn;
     }
 
+    Log(LogSeverity::Info, "Change journal monitor started for %c:", driveLetter);
     m_running.store(true);
     m_monitorThread = std::thread(&ChangeJournalMonitor::MonitorThread, this);
     return true;
@@ -116,6 +120,8 @@ void ChangeJournalMonitor::MonitorThread() {
             DWORD err = GetLastError();
             if (err == ERROR_JOURNAL_ENTRY_DELETED) {
                 // Journal wrapped around; reset to current position
+                Log(LogSeverity::Error, "USN journal wrapped for %c: — resetting",
+                    m_driveLetter);
                 USN_JOURNAL_DATA_V0 journalData = {};
                 DeviceIoControl(m_volumeHandle, FSCTL_QUERY_USN_JOURNAL,
                                 nullptr, 0, &journalData, sizeof(journalData),
@@ -152,6 +158,10 @@ void ChangeJournalMonitor::MonitorThread() {
         m_lastUsn = nextUsn;
 
         // Resolve parent references to paths and queue rescans
+        if (!affectedParents.empty()) {
+            Log(LogSeverity::Verbose, "USN: %d changed paths on %c:",
+                static_cast<int>(affectedParents.size()), m_driveLetter);
+        }
         for (DWORDLONG parentRef : affectedParents) {
             std::wstring parentPath = ResolveFileReference(parentRef);
             if (!parentPath.empty()) {

--- a/service/ipc_server.cpp
+++ b/service/ipc_server.cpp
@@ -1,6 +1,8 @@
 #include "ipc_server.h"
 #include "scanner.h"
+#include "log_buffer.h"
 
+#include <filesystem>
 #include <vector>
 
 namespace dirsize {
@@ -106,21 +108,30 @@ void IpcServer::HandleClient(HANDLE hPipe) {
         return;
     }
 
-    // Read path if present
+    // Read payload if present (raw bytes — interpreted per command)
+    std::vector<uint8_t> rawPayload;
     std::wstring path;
     if (reqHeader.pathLengthBytes > 0) {
-        std::vector<wchar_t> pathBuf(reqHeader.pathLengthBytes / sizeof(wchar_t));
-        if (!ReadFile(hPipe, pathBuf.data(), reqHeader.pathLengthBytes, &bytesRead, nullptr) ||
+        rawPayload.resize(reqHeader.pathLengthBytes);
+        if (!ReadFile(hPipe, rawPayload.data(), reqHeader.pathLengthBytes, &bytesRead, nullptr) ||
             bytesRead != reqHeader.pathLengthBytes) {
             return;
         }
-        path.assign(pathBuf.data(), pathBuf.size() - 1); // Exclude null terminator
+        // For most commands, the payload is a null-terminated wchar_t path
+        if (reqHeader.command != IpcCommand::GetLog) {
+            auto* wchars = reinterpret_cast<const wchar_t*>(rawPayload.data());
+            size_t wcharCount = reqHeader.pathLengthBytes / sizeof(wchar_t);
+            if (wcharCount > 0) {
+                path.assign(wchars, wcharCount - 1); // Exclude null terminator
+            }
+        }
     }
 
     // Process command
     IpcResponseHeader response;
     response.status = IpcStatus::Ok;
     response.dataLengthBytes = 0;
+    bool responseSent = false;
 
     switch (reqHeader.command) {
     case IpcCommand::Recalculate:
@@ -143,14 +154,99 @@ void IpcServer::HandleClient(HANDLE hPipe) {
         }
         break;
 
+    case IpcCommand::GetLog: {
+        // Read sinceSeqNum from raw payload
+        uint32_t sinceSeqNum = 0;
+        if (rawPayload.size() >= sizeof(uint32_t)) {
+            std::memcpy(&sinceSeqNum, rawPayload.data(), sizeof(uint32_t));
+        }
+
+        // Build status info
+        ServiceStatusWire statusInfo = {};
+        if (m_scanner) {
+            statusInfo.isScanning = m_scanner->IsScanning() ? 1 : 0;
+            statusInfo.lastScanTimestamp = m_scanner->GetLastFullScanTime();
+        }
+        if (m_db) {
+            statusInfo.dbEntryCount = m_db->GetEntryCount();
+        }
+        // Get DB file size
+        try {
+            auto dbPath = Database::GetDefaultPath();
+            statusInfo.dbSizeBytes = std::filesystem::file_size(dbPath);
+        } catch (...) {
+            statusInfo.dbSizeBytes = 0;
+        }
+
+        // Get current scan path (convert to UTF-8)
+        std::string currentPathUtf8;
+        if (m_scanner) {
+            std::wstring currentPath = m_scanner->GetCurrentPath();
+            if (!currentPath.empty()) {
+                int needed = WideCharToMultiByte(CP_UTF8, 0, currentPath.c_str(), -1,
+                                                 nullptr, 0, nullptr, nullptr);
+                if (needed > 0) {
+                    currentPathUtf8.resize(needed - 1);
+                    WideCharToMultiByte(CP_UTF8, 0, currentPath.c_str(), -1,
+                                        currentPathUtf8.data(), needed, nullptr, nullptr);
+                }
+            }
+        }
+        statusInfo.currentPathLength = static_cast<uint16_t>(currentPathUtf8.size());
+
+        // Serialize log entries
+        std::vector<uint8_t> logData;
+        bool truncated = false;
+        uint32_t latestSeq = GetLogBuffer().Serialize(sinceSeqNum, logData, truncated);
+        if (truncated) {
+            latestSeq |= 0x80000000u;
+        }
+
+        // Build full payload: latestSeqNum + ServiceStatusWire + currentPath + logData
+        size_t payloadSize = sizeof(uint32_t) + sizeof(ServiceStatusWire)
+                           + currentPathUtf8.size() + logData.size();
+        std::vector<uint8_t> payload(payloadSize);
+        size_t offset = 0;
+
+        std::memcpy(payload.data() + offset, &latestSeq, sizeof(uint32_t));
+        offset += sizeof(uint32_t);
+
+        std::memcpy(payload.data() + offset, &statusInfo, sizeof(ServiceStatusWire));
+        offset += sizeof(ServiceStatusWire);
+
+        if (!currentPathUtf8.empty()) {
+            std::memcpy(payload.data() + offset, currentPathUtf8.data(),
+                        currentPathUtf8.size());
+            offset += currentPathUtf8.size();
+        }
+
+        if (!logData.empty()) {
+            std::memcpy(payload.data() + offset, logData.data(), logData.size());
+        }
+
+        response.dataLengthBytes = static_cast<uint32_t>(payloadSize);
+        DWORD bytesWritten = 0;
+        WriteFile(hPipe, &response, sizeof(response), &bytesWritten, nullptr);
+        if (!payload.empty()) {
+            WriteFile(hPipe, payload.data(), response.dataLengthBytes,
+                      &bytesWritten, nullptr);
+        }
+        responseSent = true;
+        break;
+    }
+
     default:
+        Log(LogSeverity::Error, "Unknown IPC command: %d",
+            static_cast<int>(reqHeader.command));
         response.status = IpcStatus::Error;
         break;
     }
 
-    // Send response
-    DWORD bytesWritten = 0;
-    WriteFile(hPipe, &response, sizeof(response), &bytesWritten, nullptr);
+    // Send response (unless already sent by GetLog)
+    if (!responseSent) {
+        DWORD bytesWritten = 0;
+        WriteFile(hPipe, &response, sizeof(response), &bytesWritten, nullptr);
+    }
 }
 
 } // namespace dirsize

--- a/service/log_buffer.cpp
+++ b/service/log_buffer.cpp
@@ -1,0 +1,130 @@
+#include "log_buffer.h"
+
+#include <Windows.h>
+
+#include <chrono>
+#include <cstdarg>
+#include <cstdio>
+#include <cstring>
+#include <algorithm>
+
+namespace dirsize {
+
+// ---------------------------------------------------------------------------
+// LogBuffer implementation
+// ---------------------------------------------------------------------------
+
+LogBuffer::LogBuffer(size_t capacity)
+    : m_capacity(capacity)
+{
+    m_ring.resize(capacity);
+}
+
+uint32_t LogBuffer::Append(LogSeverity severity, const std::string& message) {
+    std::lock_guard<std::mutex> lock(m_mutex);
+
+    auto now = std::chrono::system_clock::now();
+    auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+        now.time_since_epoch()).count();
+
+    Entry& entry = m_ring[m_head];
+    entry.seqNum = m_nextSeqNum;
+    entry.timestampMs = ms;
+    entry.severity = severity;
+    // Truncate very long messages to avoid bloating the buffer
+    entry.message = message.size() > 4096 ? message.substr(0, 4096) : message;
+
+    m_head = (m_head + 1) % m_capacity;
+    if (m_count < m_capacity) {
+        m_count++;
+    }
+
+    return m_nextSeqNum++;
+}
+
+uint32_t LogBuffer::Serialize(uint32_t sinceSeqNum, std::vector<uint8_t>& outData,
+                               bool& truncated) const {
+    std::lock_guard<std::mutex> lock(m_mutex);
+
+    outData.clear();
+    truncated = false;
+
+    if (m_count == 0) {
+        return 0;
+    }
+
+    uint32_t latestSeq = m_nextSeqNum - 1;
+
+    // Find the oldest entry's sequence number
+    size_t oldestIdx = (m_count < m_capacity) ? 0 : m_head;
+    uint32_t oldestSeq = m_ring[oldestIdx].seqNum;
+
+    // If the requested sequence number is older than our oldest entry,
+    // the client's data has been evicted — signal truncation
+    if (sinceSeqNum > 0 && sinceSeqNum < oldestSeq) {
+        truncated = true;
+    }
+
+    // Iterate from oldest to newest and serialize entries newer than sinceSeqNum
+    for (size_t i = 0; i < m_count; i++) {
+        size_t idx = (oldestIdx + i) % m_capacity;
+        const Entry& e = m_ring[idx];
+
+        if (e.seqNum <= sinceSeqNum) {
+            continue;
+        }
+
+        // Serialize as LogEntryWire + message bytes
+        LogEntryWire wire;
+        wire.timestampMs = e.timestampMs;
+        wire.severity = e.severity;
+        wire.messageLength = static_cast<uint16_t>(
+            std::min(e.message.size(), static_cast<size_t>(UINT16_MAX)));
+
+        size_t offset = outData.size();
+        outData.resize(offset + sizeof(LogEntryWire) + wire.messageLength);
+        std::memcpy(outData.data() + offset, &wire, sizeof(LogEntryWire));
+        std::memcpy(outData.data() + offset + sizeof(LogEntryWire),
+                     e.message.data(), wire.messageLength);
+    }
+
+    return latestSeq;
+}
+
+// ---------------------------------------------------------------------------
+// Singleton and convenience functions
+// ---------------------------------------------------------------------------
+
+LogBuffer& GetLogBuffer() {
+    static LogBuffer instance(500);
+    return instance;
+}
+
+void Log(LogSeverity severity, const char* fmt, ...) {
+    char buf[4096];
+    va_list args;
+    va_start(args, fmt);
+    vsnprintf(buf, sizeof(buf), fmt, args);
+    va_end(args);
+
+    GetLogBuffer().Append(severity, std::string(buf));
+}
+
+void Log(LogSeverity severity, const wchar_t* fmt, ...) {
+    wchar_t wbuf[4096];
+    va_list args;
+    va_start(args, fmt);
+    _vsnwprintf_s(wbuf, _countof(wbuf), _TRUNCATE, fmt, args);
+    va_end(args);
+
+    // Convert wide string to UTF-8
+    int needed = WideCharToMultiByte(CP_UTF8, 0, wbuf, -1, nullptr, 0, nullptr, nullptr);
+    if (needed > 0) {
+        std::string utf8(needed - 1, '\0');
+        WideCharToMultiByte(CP_UTF8, 0, wbuf, -1, utf8.data(),
+                            needed, nullptr, nullptr);
+        GetLogBuffer().Append(severity, utf8);
+    }
+}
+
+} // namespace dirsize

--- a/service/log_buffer.h
+++ b/service/log_buffer.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "dirsize/ipc.h"
+
+#include <cstdint>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace dirsize {
+
+// Thread-safe circular buffer holding the last N log entries.
+// Used by the service to record operational events; retrieved by the
+// tray app via the GetLog IPC command.
+class LogBuffer {
+public:
+    explicit LogBuffer(size_t capacity = 500);
+
+    // Append a log entry. Returns the assigned sequence number.
+    uint32_t Append(LogSeverity severity, const std::string& message);
+
+    // Serialize all entries with seqNum > sinceSeqNum into a byte vector
+    // of LogEntryWire records. Returns the latest sequence number.
+    // Sets truncated=true if sinceSeqNum entries have been evicted
+    // (caller should clear its display and re-render).
+    uint32_t Serialize(uint32_t sinceSeqNum, std::vector<uint8_t>& outData,
+                       bool& truncated) const;
+
+private:
+    struct Entry {
+        uint32_t seqNum = 0;
+        int64_t timestampMs = 0;
+        LogSeverity severity = LogSeverity::Info;
+        std::string message;    // UTF-8
+    };
+
+    mutable std::mutex m_mutex;
+    std::vector<Entry> m_ring;
+    size_t m_capacity;
+    size_t m_head = 0;          // Next write position
+    size_t m_count = 0;         // Current number of entries (<= capacity)
+    uint32_t m_nextSeqNum = 1;  // Monotonically increasing
+};
+
+// Singleton accessor — the LogBuffer lives for the lifetime of the service.
+LogBuffer& GetLogBuffer();
+
+// Convenience logging functions. Format the message and append to the
+// global ring buffer. The wide-char overload converts to UTF-8 internally.
+void Log(LogSeverity severity, const char* fmt, ...);
+void Log(LogSeverity severity, const wchar_t* fmt, ...);
+
+} // namespace dirsize

--- a/service/scanner.cpp
+++ b/service/scanner.cpp
@@ -1,4 +1,5 @@
 #include "scanner.h"
+#include "log_buffer.h"
 
 #include <chrono>
 #include <algorithm>
@@ -41,6 +42,7 @@ void Scanner::QueueRescan(const std::wstring& path) {
         std::lock_guard lock(m_queueMutex);
         m_rescanQueue.push(path);
     }
+    Log(LogSeverity::Verbose, L"Rescan queued: %s", path.c_str());
     if (m_rescanEvent) SetEvent(m_rescanEvent);
 }
 
@@ -51,8 +53,19 @@ void Scanner::ReloadConfig() {
         m_config = newConfig;
         m_throttle.SetLevel(newConfig.ioPriority);
     }
+    Log(LogSeverity::Info, "Configuration reloaded");
     // Wake the scheduler so it picks up the new interval
     if (m_rescanEvent) SetEvent(m_rescanEvent);
+}
+
+std::wstring Scanner::GetCurrentPath() const {
+    std::lock_guard lock(m_stateMutex);
+    return m_currentScanPath;
+}
+
+int64_t Scanner::GetLastFullScanTime() const {
+    std::lock_guard lock(m_stateMutex);
+    return m_lastFullScanTime;
 }
 
 void Scanner::SchedulerThread() {
@@ -110,11 +123,27 @@ void Scanner::FullScan() {
         watchedDirs = m_config.watchedDirs;
     }
 
+    Log(LogSeverity::Info, "Full scan started (%d directories)",
+        static_cast<int>(watchedDirs.size()));
+    auto fullScanStart = std::chrono::steady_clock::now();
+
     for (const auto& rootDir : watchedDirs) {
         if (WaitForSingleObject(m_stopEvent, 0) == WAIT_OBJECT_0) break;
 
+        {
+            std::lock_guard lock(m_stateMutex);
+            m_currentScanPath = rootDir;
+        }
+        Log(LogSeverity::Verbose, L"Scanning %s", rootDir.c_str());
+        auto dirStart = std::chrono::steady_clock::now();
+
         std::vector<DirEntry> entries;
-        ScanDirectory(rootDir, 0, entries);
+        ScanResult result = ScanDirectory(rootDir, 0, entries);
+
+        auto dirElapsed = std::chrono::duration<double>(
+            std::chrono::steady_clock::now() - dirStart).count();
+        Log(LogSeverity::Info, L"Scanned %s \u2014 %llu files, %llu dirs, %.1fs",
+            rootDir.c_str(), result.fileCount, result.dirCount, dirElapsed);
 
         // Batch write in chunks to avoid holding the DB lock too long
         constexpr size_t kBatchSize = 500;
@@ -126,6 +155,18 @@ void Scanner::FullScan() {
             m_db->UpsertEntries(batch);
         }
     }
+
+    {
+        std::lock_guard lock(m_stateMutex);
+        m_currentScanPath.clear();
+        auto now = std::chrono::system_clock::now();
+        m_lastFullScanTime = std::chrono::duration_cast<std::chrono::milliseconds>(
+            now.time_since_epoch()).count();
+    }
+
+    auto fullElapsed = std::chrono::duration<double>(
+        std::chrono::steady_clock::now() - fullScanStart).count();
+    Log(LogSeverity::Info, "Full scan completed in %.1f seconds", fullElapsed);
 
     m_scanning.store(false);
 }
@@ -154,6 +195,10 @@ ScanResult Scanner::ScanDirectory(const std::wstring& rootPath, int depth,
         FIND_FIRST_EX_LARGE_FETCH);
 
     if (hFind == INVALID_HANDLE_VALUE) {
+        DWORD err = GetLastError();
+        if (err == ERROR_ACCESS_DENIED) {
+            Log(LogSeverity::Verbose, L"Access denied: %s", rootPath.c_str());
+        }
         return result;
     }
 

--- a/service/scanner.h
+++ b/service/scanner.h
@@ -45,6 +45,10 @@ public:
 
     bool IsScanning() const { return m_scanning.load(); }
 
+    // Accessors for status reporting (used by IPC GetLog command)
+    std::wstring GetCurrentPath() const;
+    int64_t GetLastFullScanTime() const;
+
 private:
     // The scheduler thread: wakes at configured intervals or when a rescan is queued.
     void SchedulerThread();
@@ -74,6 +78,11 @@ private:
     // Cluster size cache (per drive letter) for allocation size computation
     std::unordered_map<wchar_t, DWORD> m_clusterSizeCache;
     DWORD GetClusterSize(wchar_t driveLetter);
+
+    // Status tracking for the Logging tab
+    mutable std::mutex m_stateMutex;
+    std::wstring m_currentScanPath;
+    int64_t m_lastFullScanTime = 0;     // Unix epoch milliseconds
 };
 
 } // namespace dirsize

--- a/service/service_control.cpp
+++ b/service/service_control.cpp
@@ -2,6 +2,7 @@
 #include "scanner.h"
 #include "ipc_server.h"
 #include "change_journal.h"
+#include "log_buffer.h"
 #include "dirsize/config.h"
 #include "dirsize/db.h"
 
@@ -44,6 +45,7 @@ DWORD WINAPI ServiceCtrlHandler(DWORD control, DWORD /*eventType*/,
     switch (control) {
     case SERVICE_CONTROL_STOP:
     case SERVICE_CONTROL_SHUTDOWN:
+        Log(LogSeverity::Info, "Service stop requested");
         ReportServiceStatus(SERVICE_STOP_PENDING, NO_ERROR, 5000);
         SetEvent(g_stopEvent);
         return NO_ERROR;
@@ -62,6 +64,7 @@ void WINAPI ServiceMain(DWORD /*argc*/, LPWSTR* /*argv*/) {
     if (!g_statusHandle) return;
 
     ReportServiceStatus(SERVICE_START_PENDING, NO_ERROR, 3000);
+    Log(LogSeverity::Info, "Service starting");
 
     // Create the global stop event
     g_stopEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);
@@ -73,6 +76,7 @@ void WINAPI ServiceMain(DWORD /*argc*/, LPWSTR* /*argv*/) {
     // Open the database in read-write mode
     auto db = std::make_shared<Database>();
     if (!db->Open(Database::GetDefaultPath(), false)) {
+        Log(LogSeverity::Error, "Failed to open database");
         ReportServiceStatus(SERVICE_STOPPED, ERROR_DATABASE_FAILURE);
         CloseHandle(g_stopEvent);
         return;
@@ -109,6 +113,9 @@ void WINAPI ServiceMain(DWORD /*argc*/, LPWSTR* /*argv*/) {
     }
 
     // Service is now running
+    Log(LogSeverity::Info, "Service running — %d watched dirs, change journal %s",
+        static_cast<int>(config.watchedDirs.size()),
+        config.useChangeJournal ? "on" : "off");
     ReportServiceStatus(SERVICE_RUNNING);
 
     // Wait for stop signal
@@ -125,6 +132,7 @@ void WINAPI ServiceMain(DWORD /*argc*/, LPWSTR* /*argv*/) {
     CloseHandle(g_stopEvent);
     g_stopEvent = nullptr;
 
+    Log(LogSeverity::Info, "Service stopped");
     ReportServiceStatus(SERVICE_STOPPED);
 }
 

--- a/tray/resource.h
+++ b/tray/resource.h
@@ -36,6 +36,14 @@
 #define IDC_BTN_CANCEL          231
 #define IDC_BTN_APPLY           232
 
+// Logging tab controls
+#define IDC_LOG_STATUS          240
+#define IDC_LOG_EDIT            241
+#define IDC_BTN_LOG_CLEAR       242
+#define IDC_BTN_LOG_COPY        243
+#define IDC_LBL_LOG_VERBOSITY   244
+#define IDC_LOG_VERBOSITY       245
+
 // Tray menu commands
 #define IDM_SETTINGS            301
 #define IDM_SCAN_NOW            302
@@ -44,3 +52,4 @@
 
 // Timer for tray
 #define IDT_TRAY_TIMER          400
+#define IDT_LOG_POLL            401

--- a/tray/resource.rc
+++ b/tray/resource.rc
@@ -54,6 +54,15 @@ BEGIN
     AUTORADIOBUTTON "Files and folders", IDC_RADIO_SCALE_ALL,
                     125, 116, 90, 10
 
+    // --- Logging Tab Controls (initially hidden) ---
+    LTEXT           "", IDC_LOG_STATUS, 20, 30, 305, 20
+    EDITTEXT        IDC_LOG_EDIT, 20, 52, 305, 165,
+                    ES_MULTILINE | ES_READONLY | ES_AUTOVSCROLL | WS_VSCROLL | WS_BORDER
+    PUSHBUTTON      "Clear", IDC_BTN_LOG_CLEAR, 20, 222, 40, 14
+    PUSHBUTTON      "Copy", IDC_BTN_LOG_COPY, 65, 222, 40, 14
+    LTEXT           "Verbosity:", IDC_LBL_LOG_VERBOSITY, 200, 224, 40, 10
+    COMBOBOX        IDC_LOG_VERBOSITY, 245, 222, 80, 60, CBS_DROPDOWNLIST | WS_VSCROLL
+
     // --- Bottom buttons ---
     DEFPUSHBUTTON   "OK", IDC_BTN_OK, 170, 255, 50, 14
     PUSHBUTTON      "Cancel", IDC_BTN_CANCEL, 225, 255, 50, 14

--- a/tray/settings_dialog.cpp
+++ b/tray/settings_dialog.cpp
@@ -6,6 +6,8 @@
 #include <CommCtrl.h>
 #include <ShlObj.h>
 
+#include <cstring>
+#include <ctime>
 #include <string>
 #include <vector>
 
@@ -29,15 +31,26 @@ const int kDisplayControls[] = {
     IDC_RADIO_SCALE_FOLDERS, IDC_RADIO_SCALE_ALL
 };
 
+// Control IDs for the logging tab
+const int kLoggingControls[] = {
+    IDC_LOG_STATUS, IDC_LOG_EDIT,
+    IDC_BTN_LOG_CLEAR, IDC_BTN_LOG_COPY,
+    IDC_LBL_LOG_VERBOSITY, IDC_LOG_VERBOSITY
+};
+
+// Logging tab state
+static uint32_t s_lastSeqNum = 0;
+static LogSeverity s_verbosityFilter = LogSeverity::Info;
+
 void ShowTabControls(HWND hDlg, int tabIndex) {
-    // Show/hide controls based on active tab
     for (int id : kScannerControls) {
         ShowWindow(GetDlgItem(hDlg, id), tabIndex == 0 ? SW_SHOW : SW_HIDE);
     }
-    // Also show/hide the static labels (they have id -1, so we use
-    // enumeration or just manage by tab index)
     for (int id : kDisplayControls) {
         ShowWindow(GetDlgItem(hDlg, id), tabIndex == 1 ? SW_SHOW : SW_HIDE);
+    }
+    for (int id : kLoggingControls) {
+        ShowWindow(GetDlgItem(hDlg, id), tabIndex == 2 ? SW_SHOW : SW_HIDE);
     }
 }
 
@@ -162,6 +175,165 @@ void BrowseForFolder(HWND hDlg) {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Logging tab helpers
+// ---------------------------------------------------------------------------
+
+static void AppendLogText(HWND hEdit, const wchar_t* text) {
+    int len = GetWindowTextLengthW(hEdit);
+    // Prevent unbounded growth — clear if over 256K chars
+    if (len > 256 * 1024) {
+        SetWindowTextW(hEdit, L"");
+        len = 0;
+    }
+    SendMessageW(hEdit, EM_SETSEL, len, len);
+    SendMessageW(hEdit, EM_REPLACESEL, FALSE, reinterpret_cast<LPARAM>(text));
+}
+
+static std::wstring Utf8ToWide(const char* utf8, int len) {
+    if (!utf8 || len == 0) return {};
+    int size = MultiByteToWideChar(CP_UTF8, 0, utf8, len, nullptr, 0);
+    std::wstring result(size, L'\0');
+    MultiByteToWideChar(CP_UTF8, 0, utf8, len, result.data(), size);
+    return result;
+}
+
+static std::wstring FormatFileSize(uint64_t bytes) {
+    wchar_t buf[64];
+    if (bytes >= 1024ULL * 1024 * 1024) {
+        _snwprintf_s(buf, _countof(buf), _TRUNCATE, L"%.1f GB",
+                     bytes / (1024.0 * 1024.0 * 1024.0));
+    } else if (bytes >= 1024ULL * 1024) {
+        _snwprintf_s(buf, _countof(buf), _TRUNCATE, L"%.1f MB",
+                     bytes / (1024.0 * 1024.0));
+    } else if (bytes >= 1024) {
+        _snwprintf_s(buf, _countof(buf), _TRUNCATE, L"%.1f KB",
+                     bytes / 1024.0);
+    } else {
+        _snwprintf_s(buf, _countof(buf), _TRUNCATE, L"%llu bytes", bytes);
+    }
+    return buf;
+}
+
+static void RefreshLog(HWND hDlg) {
+    IpcStatus status;
+    uint32_t latestSeqNum = 0;
+    std::vector<uint8_t> data;
+
+    if (!SendGetLog(s_lastSeqNum, status, latestSeqNum, data, 1500)) {
+        // Don't overwrite a good status with "not connected" on a transient failure
+        // Only show "not connected" if we've never received data
+        if (s_lastSeqNum == 0) {
+            SetDlgItemTextW(hDlg, IDC_LOG_STATUS, L"Service not connected");
+        }
+        return;
+    }
+
+    // Check truncation bit
+    bool truncated = (latestSeqNum & 0x80000000u) != 0;
+    latestSeqNum &= 0x7FFFFFFFu;
+
+    if (truncated) {
+        SetDlgItemTextW(hDlg, IDC_LOG_EDIT, L"");
+    }
+    s_lastSeqNum = latestSeqNum;
+
+    if (data.size() < sizeof(ServiceStatusWire)) {
+        return;
+    }
+
+    // Parse ServiceStatusWire
+    size_t offset = 0;
+    ServiceStatusWire statusInfo;
+    std::memcpy(&statusInfo, data.data() + offset, sizeof(ServiceStatusWire));
+    offset += sizeof(ServiceStatusWire);
+
+    // Read current scan path
+    std::wstring currentPath;
+    if (statusInfo.currentPathLength > 0 &&
+        offset + statusInfo.currentPathLength <= data.size()) {
+        currentPath = Utf8ToWide(
+            reinterpret_cast<const char*>(data.data() + offset),
+            statusInfo.currentPathLength);
+        offset += statusInfo.currentPathLength;
+    }
+
+    // Build status text
+    wchar_t statusText[512];
+    if (statusInfo.isScanning && !currentPath.empty()) {
+        _snwprintf_s(statusText, _countof(statusText), _TRUNCATE,
+            L"Status: Scanning %s | DB: %llu entries (%s)",
+            currentPath.c_str(), statusInfo.dbEntryCount,
+            FormatFileSize(statusInfo.dbSizeBytes).c_str());
+    } else {
+        // Format last scan time
+        wchar_t timeStr[32] = L"Never";
+        if (statusInfo.lastScanTimestamp > 0) {
+            time_t t = static_cast<time_t>(statusInfo.lastScanTimestamp / 1000);
+            struct tm localTm;
+            localtime_s(&localTm, &t);
+            wcsftime(timeStr, _countof(timeStr), L"%I:%M %p", &localTm);
+        }
+        _snwprintf_s(statusText, _countof(statusText), _TRUNCATE,
+            L"Status: Idle | DB: %llu entries (%s) | Last scan: %s",
+            statusInfo.dbEntryCount,
+            FormatFileSize(statusInfo.dbSizeBytes).c_str(),
+            timeStr);
+    }
+    SetDlgItemTextW(hDlg, IDC_LOG_STATUS, statusText);
+
+    // Parse and display log entries
+    HWND hEdit = GetDlgItem(hDlg, IDC_LOG_EDIT);
+    std::wstring appendBuf;
+
+    while (offset + sizeof(LogEntryWire) <= data.size()) {
+        LogEntryWire wire;
+        std::memcpy(&wire, data.data() + offset, sizeof(LogEntryWire));
+        offset += sizeof(LogEntryWire);
+
+        if (offset + wire.messageLength > data.size()) {
+            break;
+        }
+
+        std::string msgUtf8(
+            reinterpret_cast<const char*>(data.data() + offset),
+            wire.messageLength);
+        offset += wire.messageLength;
+
+        // Apply verbosity filter (client-side)
+        if (static_cast<uint8_t>(wire.severity) >
+            static_cast<uint8_t>(s_verbosityFilter)) {
+            continue;
+        }
+
+        // Format timestamp as HH:MM:SS
+        time_t t = static_cast<time_t>(wire.timestampMs / 1000);
+        struct tm localTm;
+        localtime_s(&localTm, &t);
+        wchar_t timeStr[16];
+        wcsftime(timeStr, _countof(timeStr), L"%H:%M:%S", &localTm);
+
+        // Severity label
+        const wchar_t* sevLabel = L"";
+        if (wire.severity == LogSeverity::Error) sevLabel = L"ERR  ";
+        else if (wire.severity == LogSeverity::Verbose) sevLabel = L"DBG  ";
+
+        std::wstring msgWide = Utf8ToWide(msgUtf8.c_str(),
+                                           static_cast<int>(msgUtf8.size()));
+
+        appendBuf += L"[";
+        appendBuf += timeStr;
+        appendBuf += L"] ";
+        appendBuf += sevLabel;
+        appendBuf += msgWide;
+        appendBuf += L"\r\n";
+    }
+
+    if (!appendBuf.empty()) {
+        AppendLogText(hEdit, appendBuf.c_str());
+    }
+}
+
 } // namespace
 
 INT_PTR CALLBACK SettingsDlgProc(HWND hDlg, UINT message,
@@ -179,7 +351,24 @@ INT_PTR CALLBACK SettingsDlgProc(HWND hDlg, UINT message,
         tie.pszText = const_cast<LPWSTR>(L"Display");
         TabCtrl_InsertItem(hTab, 1, &tie);
 
+        tie.pszText = const_cast<LPWSTR>(L"Logging");
+        TabCtrl_InsertItem(hTab, 2, &tie);
+
         LoadSettingsToDialog(hDlg);
+
+        // Initialize logging tab controls
+        HWND hVerbosity = GetDlgItem(hDlg, IDC_LOG_VERBOSITY);
+        SendMessageW(hVerbosity, CB_ADDSTRING, 0,
+                     reinterpret_cast<LPARAM>(L"Errors only"));
+        SendMessageW(hVerbosity, CB_ADDSTRING, 0,
+                     reinterpret_cast<LPARAM>(L"Normal"));
+        SendMessageW(hVerbosity, CB_ADDSTRING, 0,
+                     reinterpret_cast<LPARAM>(L"Verbose"));
+        SendMessageW(hVerbosity, CB_SETCURSEL, 1, 0);  // Default: Normal
+
+        // Set edit control text limit
+        SendDlgItemMessageW(hDlg, IDC_LOG_EDIT, EM_SETLIMITTEXT, 256 * 1024, 0);
+
         ShowTabControls(hDlg, 0);
         return TRUE;
     }
@@ -189,19 +378,35 @@ INT_PTR CALLBACK SettingsDlgProc(HWND hDlg, UINT message,
         if (pnmh && pnmh->idFrom == IDC_TAB_CONTROL && pnmh->code == TCN_SELCHANGE) {
             int tabIndex = TabCtrl_GetCurSel(GetDlgItem(hDlg, IDC_TAB_CONTROL));
             ShowTabControls(hDlg, tabIndex);
+
+            if (tabIndex == 2) {
+                // Start polling and do an immediate refresh
+                SetTimer(hDlg, IDT_LOG_POLL, 2000, nullptr);
+                RefreshLog(hDlg);
+            } else {
+                KillTimer(hDlg, IDT_LOG_POLL);
+            }
         }
         break;
     }
+
+    case WM_TIMER:
+        if (wParam == IDT_LOG_POLL) {
+            RefreshLog(hDlg);
+        }
+        return TRUE;
 
     case WM_COMMAND:
         switch (LOWORD(wParam)) {
         case IDC_BTN_OK:
             if (SaveSettingsFromDialog(hDlg)) {
+                KillTimer(hDlg, IDT_LOG_POLL);
                 DestroyWindow(hDlg);
             }
             return TRUE;
 
         case IDC_BTN_CANCEL:
+            KillTimer(hDlg, IDT_LOG_POLL);
             DestroyWindow(hDlg);
             return TRUE;
 
@@ -229,10 +434,37 @@ INT_PTR CALLBACK SettingsDlgProc(HWND hDlg, UINT message,
             }
             return TRUE;
         }
+
+        case IDC_BTN_LOG_CLEAR:
+            SetDlgItemTextW(hDlg, IDC_LOG_EDIT, L"");
+            s_lastSeqNum = 0;
+            return TRUE;
+
+        case IDC_BTN_LOG_COPY: {
+            HWND hEdit = GetDlgItem(hDlg, IDC_LOG_EDIT);
+            SendMessageW(hEdit, EM_SETSEL, 0, -1);
+            SendMessageW(hEdit, WM_COPY, 0, 0);
+            SendMessageW(hEdit, EM_SETSEL, -1, -1);
+            return TRUE;
+        }
+
+        case IDC_LOG_VERBOSITY:
+            if (HIWORD(wParam) == CBN_SELCHANGE) {
+                int sel = static_cast<int>(
+                    SendDlgItemMessageW(hDlg, IDC_LOG_VERBOSITY,
+                                        CB_GETCURSEL, 0, 0));
+                s_verbosityFilter = static_cast<LogSeverity>(sel);
+                // Clear and re-fetch to apply new filter
+                SetDlgItemTextW(hDlg, IDC_LOG_EDIT, L"");
+                s_lastSeqNum = 0;
+                RefreshLog(hDlg);
+            }
+            return TRUE;
         }
         break;
 
     case WM_CLOSE:
+        KillTimer(hDlg, IDT_LOG_POLL);
         DestroyWindow(hDlg);
         return TRUE;
     }


### PR DESCRIPTION
## Summary
- **Service**: Ring buffer logger (500 entries) with `Log()` instrumentation across scanner, IPC server, change journal, and service lifecycle events
- **IPC**: New `GetLog` command (code 4) returns log entries + service status (scanning state, DB entry count/size, current scan path) via packed binary wire protocol
- **Tray GUI**: Third "Logging" tab with auto-refreshing log view (2s polling), status summary line, client-side verbosity filter (Errors only / Normal / Verbose), and Clear/Copy controls

## Test plan
- [x] Build all targets — no errors or warnings
- [x] Settings dialog shows 3 tabs: Scanner, Display, Logging
- [x] Status line shows service state (Idle/Scanning), DB entry count, last scan time
- [x] Log entries populate with scan activity and lifecycle events
- [x] Live updates appear every 2 seconds while on Logging tab
- [x] Verbosity filter correctly hides/shows entries by severity
- [x] Clear button resets log; new entries appear on next poll
- [x] Copy button puts log text on clipboard
- [x] "Service not connected" shown gracefully when service is stopped
- [x] Timer starts/stops correctly when switching to/from Logging tab

Fixes #24