### PR TITLE
Filter USN journal rescans to watched directories only

### DIFF
--- a/service/change_journal.cpp
+++ b/service/change_journal.cpp
@@ -158,15 +158,17 @@ void ChangeJournalMonitor::MonitorThread() {
         m_lastUsn = nextUsn;
 
         // Resolve parent references to paths and queue rescans
-        if (!affectedParents.empty()) {
-            Log(LogSeverity::Verbose, "USN: %d changed paths on %c:",
-                static_cast<int>(affectedParents.size()), m_driveLetter);
-        }
+        int queued = 0;
         for (DWORDLONG parentRef : affectedParents) {
             std::wstring parentPath = ResolveFileReference(parentRef);
             if (!parentPath.empty()) {
-                m_scanner.QueueRescan(parentPath);
+                if (m_scanner.QueueRescan(parentPath))
+                    queued++;
             }
+        }
+        if (!affectedParents.empty()) {
+            Log(LogSeverity::Verbose, "USN: %d of %d changes queued on %c:",
+                queued, static_cast<int>(affectedParents.size()), m_driveLetter);
         }
 
         // Persist the bookmark

--- a/service/scanner.cpp
+++ b/service/scanner.cpp
@@ -6,6 +6,15 @@
 
 namespace dirsize {
 
+// Check whether `path` is equal to or a child of `dir` (case-insensitive).
+static bool IsUnderDirectory(const std::wstring& path, const std::wstring& dir) {
+    if (path.size() < dir.size()) return false;
+    if (_wcsnicmp(path.c_str(), dir.c_str(), dir.size()) != 0) return false;
+    if (path.size() == dir.size()) return true;
+    if (!dir.empty() && dir.back() == L'\\') return true;
+    return path[dir.size()] == L'\\';
+}
+
 Scanner::Scanner(std::shared_ptr<Database> db, const Config& config)
     : m_db(std::move(db))
     , m_config(config)
@@ -37,13 +46,28 @@ void Scanner::Stop() {
     }
 }
 
-void Scanner::QueueRescan(const std::wstring& path) {
+bool Scanner::QueueRescan(const std::wstring& path) {
+    // Only rescan paths that fall under a watched directory.
+    {
+        std::lock_guard lock(m_configMutex);
+        bool underWatched = false;
+        for (const auto& watchedDir : m_config.watchedDirs) {
+            if (IsUnderDirectory(path, watchedDir)) {
+                underWatched = true;
+                break;
+            }
+        }
+        if (!underWatched) {
+            return false;
+        }
+    }
     {
         std::lock_guard lock(m_queueMutex);
         m_rescanQueue.push(path);
     }
     Log(LogSeverity::Verbose, L"Rescan queued: %s", path.c_str());
     if (m_rescanEvent) SetEvent(m_rescanEvent);
+    return true;
 }
 
 void Scanner::ReloadConfig() {

--- a/service/scanner.h
+++ b/service/scanner.h
@@ -38,7 +38,8 @@ public:
     void Stop();
 
     // Queue a specific path for immediate rescan (used by IPC "Recalculate" and USN monitor).
-    void QueueRescan(const std::wstring& path);
+    // Returns true if the path was queued, false if filtered out (not under a watched dir).
+    bool QueueRescan(const std::wstring& path);
 
     // Reload configuration (e.g., after tray app changes settings).
     void ReloadConfig();


### PR DESCRIPTION
## Summary
- The USN change journal API operates at the volume level, so the monitor was processing **every** change on the entire drive — including paths outside configured watched directories
- `QueueRescan()` now validates that the path falls under a watched directory before accepting it, using case-insensitive prefix matching with proper path boundary handling
- The USN verbose log line now reports queued vs total changes (e.g. `USN: 2 of 47 changes queued on C:`) for visibility into filtering effectiveness

## Test plan
- [x] Build and deploy the updated `DirSizeSvc.exe`
- [x] Set watched directories to a specific subdirectory (not a drive root)
- [x] Enable verbose logging and verify "Rescan queued" only appears for paths under watched dirs
- [x] Verify the USN summary line shows filtered counts (e.g. `USN: 2 of 47 changes queued on C:`)
- [x] Confirm directory sizes still update correctly for watched directories after file changes